### PR TITLE
added some more api functions

### DIFF
--- a/brfunds/api.py
+++ b/brfunds/api.py
@@ -1,14 +1,25 @@
-from typing import List
+from typing import Iterator, List
 
 import requests
+import datetime
 
-api_url = 'https://api.compareativos.com.br/assets/'
+
+assets_url = 'https://api.compareativos.com.br/assets'
+funds_url = 'https://api.compareativos.com.br/fund'
+
+
+def as_date(epoch_dates: List[int]) -> Iterator[datetime.date]:
+    """Transforms a list of dates in epoch milliseconds into an iterable of datetime.dates
+
+    The api frequently returns dates as a list of dates in epoch milliseconds.
+    """
+    return (datetime.date.fromtimestamp(epoch_ms / 1000) for epoch_ms in epoch_dates)
 
 
 def search(name: str, rows: int = 1, offset: int = 0):
     """Return the search data for funds found with the given name
     """
-    response = requests.get(f'{api_url}/list',
+    response = requests.get(f'{assets_url}/list',
                             params={
                                 'search': name,
                                 'rows': rows,
@@ -20,22 +31,25 @@ def search(name: str, rows: int = 1, offset: int = 0):
         raise RequestError(response.status_code)
 
 
-def cnpj_info(cnpj_id: int):
+def cnpj_info(*cnpj_ids: int):
     """Return the company info using the cnpj id
     """
-    response = requests.get(f'{api_url}/{cnpj_id}/info')
+    cnpj_id = _join(cnpj_ids)
+
+    response = requests.get(f'{assets_url}/{cnpj_id}/info')
     if response.ok:
         return response.json()
     else:
         raise RequestError(response.status_code)
 
 
-def fund_info(fund_id: str, indicators: List[str] = None):
+def benchmark_info(*fund_ids: str, benchmarks: List[str] = None):
     """Return the fund info using the fund id
     """
-    indicator_arg = '' if indicators is None else ','.join(indicators)
+    fund_id = _join(fund_ids)
+    indicator_arg = '' if benchmarks is None else ','.join(benchmarks)
 
-    response = requests.get(f'{api_url}/{fund_id}/rentability/chart',
+    response = requests.get(f'{assets_url}/{fund_id}/rentability/chart',
                             params={
                                 'indicators': indicator_arg
                             })
@@ -43,6 +57,46 @@ def fund_info(fund_id: str, indicators: List[str] = None):
         return response.json()
     else:
         raise RequestError(response.status_code)
+
+
+def volatility_info(*fund_ids: str):
+    """Return the volatility info of the given fund
+    """
+    fund_id = _join(fund_ids)
+
+    response = requests.get(f'{assets_url}/{fund_id}/volatility/chart')
+    if response.ok:
+        return response.json()
+    else:
+        raise RequestError(response.status_code)
+
+
+def shareholder_info(*cpnj_ids: int):
+    """Return the shareholder info of the given fund
+    """
+    cpnj_id = _join(cpnj_ids)
+
+    response = requests.get(f'{funds_url}/{cpnj_id}/amountShareholders/chart')
+    if response.ok:
+        return response.json()
+    else:
+        raise RequestError(response.status_code)
+
+
+def networth_info(*cpnj_ids: int):
+    """Return the net worth info from the given fund
+    """
+    cpnj_id = _join(cpnj_ids)
+
+    response = requests.get(f'{funds_url}/{cpnj_id}/netWorth/chart')
+    if response.ok:
+        return response.json()
+    else:
+        raise RequestError(response.status_code)
+
+
+def _join(terms):
+    return ','.join(str(term) for term in terms)
 
 
 class RequestError(Exception):


### PR DESCRIPTION
The volatility function might be extra, but the shareholder and networth functions should help replace the current functionality. 

The `as_date` function should also help in converting the epoch millisecond lists to `datetime.dates`

Also made the functions take in an arbitrary number of ids since the api also accepted it. It seems to have the expected behavior except in the benchmark api, where only one set of cdi/ibovespa/ipca/poupanca is returned.

