### PR TITLE
Revert "set the search type to Funds only"

### DIFF
--- a/brfunds/api.py
+++ b/brfunds/api.py
@@ -22,8 +22,7 @@ def search(name: str, rows: int = 20, offset: int = 0) -> List:
                             params={
                                 'search': name,
                                 'rows': rows,
-                                'offset': offset,
-                                'type': 'FI'
+                                'offset': offset
                             })
     if response.ok:
         return response.json()


### PR DESCRIPTION
Reverts Phactos/brfunds#5

The `/fund/` api didn't take in the `type`, only the `/assets/` api did.